### PR TITLE
updates for the QE testing

### DIFF
--- a/cluster-image-build.sh.aliyun
+++ b/cluster-image-build.sh.aliyun
@@ -56,7 +56,7 @@ then
 fi
 
 ## Assisted Installer Section ##
-export AY_OCP_VERSION="4.15.14"
+export AY_OCP_VERSION=${AY_OCP_VERSION:-"4.15.14"}
 export AY_MANIFESTS_DIR="$SRC_DIR/.ai/manifests"
 mkdir -p "$AY_MANIFESTS_DIR"
 

--- a/infra/ros/template.ros.yaml
+++ b/infra/ros/template.ros.yaml
@@ -42,19 +42,13 @@ Parameters:
   # ECS
   MasterInstanceType:
     Type: String
-    Default: ecs.g6.3xlarge
+    Default: ecs.g6.xlarge
   WorkerInstanceType:
     Type: String
-    Default: ecs.g6.2xlarge
+    Default: ecs.g6.large
   InstallerSystemDiskSize:
     Type: Number
-    Default: 500
-  BootstrapInstanceType:
-    Type: String
-    Default: ecs.g6.xlarge
-  BootstrapSystemDiskSize:
-    Type: Number
-    Default: 500
+    Default: 100
   # Imgage Ids on eu-central-1
   # RHEL: m-gw8ei55k4akujv5mqvrv (asks password?)
   # CentOS: centos_7_9_x64_20G_alibase_20240220.vhd (ssh ok)
@@ -64,7 +58,7 @@ Parameters:
     Default: aliyun_3_9_x64_20G_alibase_20231219.vhd
   AllocatePublicIP:
     Type: String
-    Default: true
+    Default: false
   InternetMaxBandwidthOut:
     Type: Number
     Default: 100
@@ -75,13 +69,13 @@ Parameters:
     Type: String
   InstanceSystemSize:
     Type: Number
-    Default: 256
+    Default: 100
   InstanceSystemLevel:
     Type: String
     Default: L1
   InstanceDataSize:
     Type: Number
-    Default: 1024
+    Default: 100
   InstanceDataLevel:
     Type: String
     Default: L1
@@ -359,15 +353,6 @@ Resources:
         Fn::Sub: ${EnvId}-bucket
       AccessControl: public-read #TODO: make private?
 
-  # NAS Instance
-  AYNASInstance:
-    Type: "ALIYUN::NAS::FileSystem"
-    Properties:
-      ProtocolType: "NFS"
-      FileSystemType: "standard"
-      StorageType: "Capacity"
-      ZoneId: !Ref ZoneAId
-
   # ECS Instances
   # AYBastionInstance:
   #  Type: "ALIYUN::ECS::Instance"
@@ -395,40 +380,6 @@ Resources:
   #      export AY_LOG=
   #      echo "Initializing installer instance with log" | tee /tmp/ay.log.txt
   #      echo "DISABLED curl -sSL https://raw.githubusercontent.com/faermanj/lab-aliyun/main/ecs-init-installer.sh | bash"
-
-  AYBootstrapInstance:
-    Type: "ALIYUN::ECS::Instance"
-    Properties:
-      InstanceName: bootstrap-instance
-      InstanceType:
-        Ref: BootstrapInstanceType
-      ImageId:
-        Ref: AIImageId
-      SecurityGroupId:
-        Ref: AYSecurityGroup
-      VSwitchId:
-        Ref: AYVSwitchA
-      ZoneId:
-        Ref: ZoneAId
-      AllocatePublicIP:
-        Ref: AllocatePublicIP
-      InternetMaxBandwidthOut:
-        Ref: InternetMaxBandwidthOut
-      KeyPairName:
-        Ref: KeyPairName
-      SystemDiskCategory: cloud_essd
-      SystemDiskSize:
-        Ref: InstanceSystemSize
-      DiskMappings:
-        - Category: cloud_essd
-          Size:
-            Ref: InstanceDataSize
-      Tags:
-        - Key: EnvId
-          Value:
-            Ref: EnvId
-        - Key: node-role.kubernetes.io/master
-          Value: ""
 
   AYMasterInstance1:
     Type: "ALIYUN::ECS::Instance"
@@ -782,98 +733,6 @@ Resources:
         Fn::GetAtt:
           - AYNLB
           - DNSName
-
-  AYBootstrapRecord:
-    Type: "ALIYUN::DNS::DomainRecord"
-    Properties:
-      DomainName:
-        Ref: DomainName
-      RR:
-        Fn::Sub: "bootstrap.${ClusterName}"
-      Type: A
-      Value:
-        Fn::GetAtt:
-          - AYBootstrapInstance
-          - PublicIp
-
-  AYMasterRecord1:
-    Type: "ALIYUN::DNS::DomainRecord"
-    Properties:
-      DomainName:
-        Ref: DomainName
-      RR:
-        Fn::Sub: "master1.${ClusterName}"
-      Type: A
-      Value:
-        Fn::GetAtt:
-          - AYMasterInstance1
-          - PublicIp
-
-  AYMasterRecord2:
-    Type: "ALIYUN::DNS::DomainRecord"
-    Properties:
-      DomainName:
-        Ref: DomainName
-      RR:
-        Fn::Sub: "master2.${ClusterName}"
-      Type: A
-      Value:
-        Fn::GetAtt:
-          - AYMasterInstance2
-          - PublicIp
-
-  AYMasterRecord3:
-    Type: "ALIYUN::DNS::DomainRecord"
-    Properties:
-      DomainName:
-        Ref: DomainName
-      RR:
-        Fn::Sub: "master3.${ClusterName}"
-      Type: A
-      Value:
-        Fn::GetAtt:
-          - AYMasterInstance3
-          - PublicIp
-
-  AYWorkerRecord1:
-    Type: "ALIYUN::DNS::DomainRecord"
-    Properties:
-      DomainName:
-        Ref: DomainName
-      RR:
-        Fn::Sub: "worker1.${ClusterName}"
-      Type: A
-      Value:
-        Fn::GetAtt:
-          - AYWorkerInstance1
-          - PublicIp
-
-  AYWorkerRecord2:
-    Type: "ALIYUN::DNS::DomainRecord"
-    Properties:
-      DomainName:
-        Ref: DomainName
-      RR:
-        Fn::Sub: "worker2.${ClusterName}"
-      Type: A
-      Value:
-        Fn::GetAtt:
-          - AYWorkerInstance2
-          - PublicIp
-
-  AYWorkerRecord3:
-    Type: "ALIYUN::DNS::DomainRecord"
-    Properties:
-      DomainName:
-        Ref: DomainName
-      RR:
-        Fn::Sub: "worker3.${ClusterName}"
-      Type: A
-      Value:
-        Fn::GetAtt:
-          - AYWorkerInstance3
-          - PublicIp
-
 
 Outputs:
   VPCID:

--- a/lab-aliyun.sh.aliyun
+++ b/lab-aliyun.sh.aliyun
@@ -1,6 +1,7 @@
 #!/bin/bash
 
+source ./setup_env.sh
 source ./cluster-image-build.sh.aliyun
 echo "Waiting for the image to be readable." 
-sleep 60
+sleep 180
 source ./ros-create-stack.sh.aliyun

--- a/ros-create-stack.sh.aliyun
+++ b/ros-create-stack.sh.aliyun
@@ -6,8 +6,8 @@ AY_REGION=${AY_REGION:-"eu-central-1"}
 AY_BUCKET_NAME=${AY_BUCKET_NAME:-"lab-ay-$AY_REGION"}
 AY_BASE_DOMAIN=${AY_BASE_DOMAIN:-"alicloud-dev.devcluster.openshift.com"}
 
-AY_ZONE_A="eu-central-1a"
-AY_ZONE_B="eu-central-1b"
+AY_ZONE_A="${AY_REGION}a"
+AY_ZONE_B="${AY_REGION}b"
 
 export ALIBABA_CLOUD_REGION_ID=$AY_REGION
 
@@ -35,7 +35,7 @@ aliyun oss cp "$DIR/infra/ros/template.ros.yaml" $AY_OBJECT_KEY --region $AY_REG
 aliyun oss set-acl $AY_OBJECT_KEY public-read --region $AY_REGION
 
 AY_TEMPLATE_URL="https://$AY_BUCKET_NAME.oss-$AY_REGION.aliyuncs.com/$AY_OBJECT_NAME"
-AY_STACK_NAME="ay-${USER}-$(date +%s)"
+AY_STACK_NAME="${AY_CLUSTER_NAME}"
 
 AY_SSH_KEY=$(cat ~/.ssh/id_rsa.pub)
 
@@ -59,6 +59,8 @@ aliyun ros CreateStack --region $AY_REGION \
     --Parameters.7.ParameterValue="$AY_BASE_DOMAIN" \
     --Parameters.8.ParameterKey="ClusterName" \
     --Parameters.8.ParameterValue="$AY_CLUSTER_NAME" \
+    --Parameters.9.ParameterKey="KeyPairName" \
+    --Parameters.9.ParameterValue="$SSH_KEY_PAIR_NAME" \
     --TemplateURL $AY_TEMPLATE_URL \
     --read-timeout 60 | tee .ay-stack-create.json
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export AY_REGION="us-east-1"
+export AY_BASE_DOMAIN="alicloud-qe.devcluster.openshift.com"
+export AY_PREFIX="jiwei-0612b-ali-"
+#export AY_OCP_VERSION="4.16.0-rc.4"
+
+export SSH_KEY_PAIR_NAME="jiwei-0606a-ali-ssh-pub-key"


### PR DESCRIPTION
1. [cluster-image-build.sh.aliyun] accept env var `AY_OCP_VERSION`
2. [infra/ros/template.ros.yaml] use minimum machine types for control-plane machines "ecs.g6.xlarge" and compute/worker machines "ecs.g6.large"
3. [infra/ros/template.ros.yaml] remove bootstrap machine, as one control-plane machine will act as bootstrap machine initially
4. [infra/ros/template.ros.yaml] do not allocate public IP for cluster machines
5. [infra/ros/template.ros.yaml] use less disk size for system disk and data disk
6. [infra/ros/template.ros.yaml] remove NAS because it's not necessary for a successful installation
7. [infra/ros/template.ros.yaml] remove the dns records of cluster machines from the base domain, as they are not necessary
8. [lab-aliyun.sh.aliyun] add `setup_env.sh` and source it
9. [lab-aliyun.sh.aliyun] wait for 180 seconds for the imported image turning into available
10. [ros-create-stack.sh.aliyun] set zones by the given region
11. [ros-create-stack.sh.aliyun] set stack name by the cluster name
12. [ros-create-stack.sh.aliyun] add parameter `KeyPairName`