### PR TITLE
create SnatEntry for NatGateway

### DIFF
--- a/cluster-image-build.sh.aliyun
+++ b/cluster-image-build.sh.aliyun
@@ -7,12 +7,13 @@ SRC_DIR=$(dirname $SCRIPT_DIR)
 VERSION="0.0.1"
 AY_REGION=${AY_REGION:-"eu-central-1"} 
 AY_PREFIX=${AY_PREFIX:-"labay"}
-AY_BUCKET_NAME=${AY_BUCKET_NAME:-"$AY_PREFIX-$AY_REGION"}
 AY_BASE_DOMAIN=${AY_BASE_DOMAIN:-"alicloud-dev.devcluster.openshift.com"}
 
 # AY_CLUSTER_NAME=${AY_CLUSTER_NAME:-"$AY_PREFIX$(date +%Y%m%d%H%M)"}
 AY_CLUSTER_NAME="$AY_PREFIX$(date +%Y%m%d%H%M%S)"
 export AY_CLUSTER_NAME
+AY_BUCKET_NAME=${AY_BUCKET_NAME:-"$AY_CLUSTER_NAME-bucket"}
+export AY_BUCKET_NAME
 
 echo "=== OpenShift LabAY Install Script $VERSION ==="
 echo "pwd: $(pwd)"
@@ -60,9 +61,12 @@ export AY_OCP_VERSION=${AY_OCP_VERSION:-"4.15.14"}
 export AY_MANIFESTS_DIR="$SRC_DIR/.ai/manifests"
 mkdir -p "$AY_MANIFESTS_DIR"
 
+AY_SSH_KEY=$(cat ~/.ssh/id_rsa.pub)
+
 aicli create cluster "$AY_CLUSTER_NAME" \
     -P openshift_version="$AY_OCP_VERSION" \
-    -P base_dns_domain="$AY_BASE_DOMAIN" 
+    -P base_dns_domain="$AY_BASE_DOMAIN" \
+    -P ssh_public_key="$AY_SSH_KEY"
 
 sleep 10 
 

--- a/infra/ros/template.ros.yaml
+++ b/infra/ros/template.ros.yaml
@@ -345,13 +345,20 @@ Resources:
       AllocationId: !Ref AYEIPA
       InstanceId: !Ref AYNatGatewayA
 
-  # Storage Bucket
-  AYBucket:
-    Type: "ALIYUN::OSS::Bucket"
+  AYSnatEntry:
+    DependsOn: AYEIPAAssociation
+    Type: ALIYUN::VPC::SnatEntry
     Properties:
-      BucketName:
-        Fn::Sub: ${EnvId}-bucket
-      AccessControl: public-read #TODO: make private?
+      SourceVSwitchIds:
+        - Ref: AYVSwitchA
+      SnatIp:
+        Fn::GetAtt:
+          - AYEIPA
+          - EipAddress          
+      SnatTableId:
+        Fn::GetAtt:
+          - AYNatGatewayA
+          - SNatTableId
 
   # ECS Instances
   # AYBastionInstance:

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -2,7 +2,7 @@
 
 export AY_REGION="us-east-1"
 export AY_BASE_DOMAIN="alicloud-qe.devcluster.openshift.com"
-export AY_PREFIX="jiwei-0612b-ali-"
-#export AY_OCP_VERSION="4.16.0-rc.4"
+export AY_PREFIX="jiwei-0701a-ali-"
+export AY_OCP_VERSION="4.16.0"
 
-export SSH_KEY_PAIR_NAME="jiwei-0606a-ali-ssh-pub-key"
+export SSH_KEY_PAIR_NAME="jiwei-test-ssh-pub-key"


### PR DESCRIPTION
1. [infra/ros/template.ros.yaml] create SnatEntry for NatGateway
2. [infra/ros/template.ros.yaml] remove "ALIYUN::OSS::Bucket" section, and instead to use the OSS bucket `<cluster name>-bucket` which is created in `cluster-image-build.sh.aliyun`
3. [cluster-image-build.sh.aliyun] provide `ssh_public_key` parameter to `aicli create cluster...`
4. [setup_env.sh] use the new ssh key pair