### PR TITLE
support Single-Node cluster and 3-Node compact cluster

### DIFF
--- a/cluster-image-build.sh.aliyun
+++ b/cluster-image-build.sh.aliyun
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -7,12 +10,21 @@ SRC_DIR=$(dirname $SCRIPT_DIR)
 VERSION="0.0.1"
 AY_REGION=${AY_REGION:-"eu-central-1"} 
 AY_PREFIX=${AY_PREFIX:-"labay"}
-AY_BUCKET_NAME=${AY_BUCKET_NAME:-"$AY_PREFIX-$AY_REGION"}
 AY_BASE_DOMAIN=${AY_BASE_DOMAIN:-"alicloud-dev.devcluster.openshift.com"}
 
-# AY_CLUSTER_NAME=${AY_CLUSTER_NAME:-"$AY_PREFIX$(date +%Y%m%d%H%M)"}
 AY_CLUSTER_NAME="$AY_PREFIX$(date +%Y%m%d%H%M%S)"
 export AY_CLUSTER_NAME
+
+AY_BUCKET_NAME=${AY_BUCKET_NAME:-"$AY_CLUSTER_NAME-bucket"}
+export AY_BUCKET_NAME
+
+SSH_PUBLIC_KEY_FILE=${SSH_PUBLIC_KEY_FILE:-"~/.ssh/id_rsa.pub"}
+if [ -f "${SSH_PUBLIC_KEY_FILE}" ]; then
+    AY_SSH_KEY=$(cat "${SSH_PUBLIC_KEY_FILE}")
+    export AY_SSH_KEY
+else
+    echo "ERROR: failed to find the ssh public key file '${SSH_PUBLIC_KEY_FILE}', abort" && exit 1
+fi
 
 echo "=== OpenShift LabAY Install Script $VERSION ==="
 echo "pwd: $(pwd)"
@@ -60,10 +72,12 @@ export AY_OCP_VERSION=${AY_OCP_VERSION:-"4.15.14"}
 export AY_MANIFESTS_DIR="$SRC_DIR/.ai/manifests"
 mkdir -p "$AY_MANIFESTS_DIR"
 
-aicli create cluster "$AY_CLUSTER_NAME" \
-    -P openshift_version="$AY_OCP_VERSION" \
-    -P base_dns_domain="$AY_BASE_DOMAIN" 
-
+cmd="aicli create cluster ${AY_CLUSTER_NAME} -P openshift_version=${AY_OCP_VERSION} -P base_dns_domain=${AY_BASE_DOMAIN} -P ssh_public_key=\"${AY_SSH_KEY}\""
+if [[ "${CREATE_SNO_CLUSTER}" == "true" ]]; then
+    cmd="${cmd} -P sno=true"
+fi
+echo "Running Command: '${cmd}'"
+eval "${cmd}"
 sleep 10 
 
 # check if iso does not exist

--- a/infra/ros/template.ros.yaml
+++ b/infra/ros/template.ros.yaml
@@ -8,6 +8,14 @@ Parameters:
   EnvId:
     Type: String
     Default: lab-ay1
+  CreateSnoCluster:
+    Description: "Whether a Single-Node cluster"
+    Type: Boolean
+    Default: false
+  CreateCompactCluster:
+    Description: "Whether a 3-Node compact cluster"
+    Type: Boolean
+    Default: false
   # Networking
   VpcCidrBlock:
     Type: String
@@ -30,14 +38,9 @@ Parameters:
   SecurityGroupName:
     Type: String
     Default: ay-cluster-sg
-  ZoneAId:
-    Type: String
-    Default: eu-central-1a
-  ZoneBId:
-    Type: String
-    Default: eu-central-1b
   # Security
-  PublicKeyBody:
+  SSHPublicKeyBody:
+    Description: "The file content of the SSH public key file"
     Type: String
   # ECS
   MasterInstanceType:
@@ -46,51 +49,58 @@ Parameters:
   WorkerInstanceType:
     Type: String
     Default: ecs.g6.large
-  InstallerSystemDiskSize:
-    Type: Number
-    Default: 100
-  # Imgage Ids on eu-central-1
-  # RHEL: m-gw8ei55k4akujv5mqvrv (asks password?)
-  # CentOS: centos_7_9_x64_20G_alibase_20240220.vhd (ssh ok)
-  # Alibaba Cloud Linux: aliyun_3_9_x64_20G_alibase_20231219.vhd
-  LinuxImageId:
-    Type: String
-    Default: aliyun_3_9_x64_20G_alibase_20231219.vhd
-  AllocatePublicIP:
-    Type: String
-    Default: false
   InternetMaxBandwidthOut:
     Type: Number
     Default: 100
-  KeyPairName:
-    Type: String
-    Default: jufaerma-eu-central-1
   AIImageId:
     Type: String
   InstanceSystemSize:
     Type: Number
     Default: 100
-  InstanceSystemLevel:
-    Type: String
-    Default: L1
   InstanceDataSize:
     Type: Number
     Default: 100
-  InstanceDataLevel:
-    Type: String
-    Default: L1
   DomainName:
     Type: String
     Default: "alicloud-dev.devcluster.openshift.com"
   ClusterName:
     Type: String
     Default: "lab-aliyun-cluster"
+  BationHostFlag:
+    Description: "Whether to create a bastion host"
+    Type: Boolean
+    Default: false
+  BastionHostImageId:
+    Description: "The image ID of the bastion host"
+    Type: String
+  BastionHostSSHKeyPair:
+    Description: "The SSH key pair to be used by the bastion host"
+    Type: String
+
+Conditions:
+  IsSno: 
+    !Equals
+      - true
+      - !Ref CreateSnoCluster
+  IsCompact: 
+    !Equals
+      - true
+      - !Ref CreateCompactCluster
+  CreateWorkerInstances:
+    !And
+      - !Not IsSno
+      - !Not IsCompact
+  CreateBationHost:
+    !Equals
+      - true
+      - !Ref BationHostFlag
+
 Resources:
-#             _                      _    
-#  _ __   ___| |___      _____  _ __| | __
-# | '_ \ / _ \ __\ \ /\ / / _ \| '__| |/ /
-# | | | |  __/ |_ \ V  V / (_) | |  |   < 
-# |_| |_|\___|\__| \_/\_/ \___/|_|  |_|\_\
+  #             _                      _    
+  #  _ __   ___| |___      _____  _ __| | __
+  # | '_ \ / _ \ __\ \ /\ / / _ \| '__| |/ /
+  # | | | |  __/ |_ \ V  V / (_) | |  |   < 
+  # |_| |_|\___|\__| \_/\_/ \___/|_|  |_|\_\
   AYVPC:
     Type: "ALIYUN::ECS::VPC"
     Properties:
@@ -107,7 +117,10 @@ Resources:
       VpcId:
         Ref: AYVPC
       ZoneId:
-        Ref: ZoneAId
+        !Select
+          - '0'
+          - !GetAZs
+              Ref: RegionId
       CidrBlock:
         Ref: VSwitchCidrBlockA
       VSwitchName:
@@ -119,7 +132,10 @@ Resources:
       VpcId:
         Ref: AYVPC
       ZoneId:
-        Ref: ZoneBId
+        !Select
+          - '1'
+          - !GetAZs
+              Ref: RegionId
       CidrBlock:
         Ref: VSwitchCidrBlockB
       VSwitchName:
@@ -158,7 +174,6 @@ Resources:
       PortRange: "22/22"
       SourceCidrIp: "0.0.0.0/0"
 
-
   AYSecurityGroupIngressTCP1936:
     Type: "ALIYUN::ECS::SecurityGroupIngress"
     Properties:
@@ -169,7 +184,6 @@ Resources:
       IpProtocol: tcp
       PortRange: "1936/1936"
       SourceCidrIp: "0.0.0.0/0"
-
 
   AYSecurityGroupIngressTCP9000_9999:
     Type: "ALIYUN::ECS::SecurityGroupIngress"
@@ -316,15 +330,48 @@ Resources:
       VpcId:
         Ref: AYVPC
       LoadBalancerName: ay-cluster-nlb
+      CrossZoneEnabled: true
       ZoneMappings:
         - VSwitchId:
             Ref: AYVSwitchA
           ZoneId:
-            Ref: ZoneAId
+            !Select
+              - '0'
+              - !GetAZs
+                  Ref: RegionId
         - VSwitchId:
             Ref: AYVSwitchB
           ZoneId:
-            Ref: ZoneBId
+            !Select
+              - '1'
+              - !GetAZs
+                  Ref: RegionId
+
+  AYNLBInternal:
+    Type: "ALIYUN::NLB::LoadBalancer"
+    Properties:
+      AddressType: "Intranet"
+      RegionId:
+        Ref: RegionId
+      VpcId:
+        Ref: AYVPC
+      LoadBalancerName: ay-cluster-nlb-internal
+      CrossZoneEnabled: true
+      ZoneMappings:
+        - VSwitchId:
+            Ref: AYVSwitchA
+          ZoneId:
+            !Select
+              - '0'
+              - !GetAZs
+                  Ref: RegionId
+        - VSwitchId:
+            Ref: AYVSwitchB
+          ZoneId:
+            !Select
+              - '1'
+              - !GetAZs
+                  Ref: RegionId
 
   # LISTENERS
   AYEIPA:
@@ -345,63 +392,114 @@ Resources:
       AllocationId: !Ref AYEIPA
       InstanceId: !Ref AYNatGatewayA
 
-  # Storage Bucket
-  AYBucket:
-    Type: "ALIYUN::OSS::Bucket"
+  AYSnatEntryA:
+    DependsOn: AYEIPAAssociation
+    Type: ALIYUN::VPC::SnatEntry
     Properties:
-      BucketName:
-        Fn::Sub: ${EnvId}-bucket
-      AccessControl: public-read #TODO: make private?
+      SourceVSwitchIds:
+        - Ref: AYVSwitchA
+      SnatIp:
+        Fn::GetAtt:
+          - AYEIPA
+          - EipAddress          
+      SnatTableId:
+        Fn::GetAtt:
+          - AYNatGatewayA
+          - SNatTableId
+
+  AYSnatEntryB:
+    DependsOn: AYEIPAAssociation
+    Type: ALIYUN::VPC::SnatEntry
+    Properties:
+      SourceVSwitchIds:
+        - Ref: AYVSwitchB
+      SnatIp:
+        Fn::GetAtt:
+          - AYEIPA
+          - EipAddress          
+      SnatTableId:
+        Fn::GetAtt:
+          - AYNatGatewayA
+          - SNatTableId
 
   # ECS Instances
-  # AYBastionInstance:
-  #  Type: "ALIYUN::ECS::Instance"
-  #  Properties:
-  #    InstanceName: installer
-  #    InstanceType:
-  #      Ref: InstallerInstanceType
-  #    ImageId:
-  #      Ref: LinuxImageId
-  #    SecurityGroupId:
-  #      Ref: AYSecurityGroup
-  #    VSwitchId:
-  #      Ref: AYVSwitchA
-  #    ZoneId:
-  #      Ref: ZoneAId
-  #    AllocatePublicIP:
-  #      Ref: AllocatePublicIP
-  #    InternetMaxBandwidthOut:
-  #      Ref: InternetMaxBandwidthOut
-  #    KeyPairName:
-  #      Ref: KeyPairName
-  #    UserData: |
-  #      #!/bin/bash
-  #      echo "Initializing installer instance"
-  #      export AY_LOG=
-  #      echo "Initializing installer instance with log" | tee /tmp/ay.log.txt
-  #      echo "DISABLED curl -sSL https://raw.githubusercontent.com/faermanj/lab-aliyun/main/ecs-init-installer.sh | bash"
+  AYSSHKeyPair:
+    Type: ALIYUN::ECS::SSHKeyPair
+    Properties:
+      KeyPairName:
+        Fn::Sub: ${EnvId}-ssh-key-pair
+      PublicKeyBody:
+        Ref: SSHPublicKeyBody
 
-  AYMasterInstance1:
+  AYBastionInstance:
+    Count:
+      !If
+        - CreateBationHost
+        - 1
+        - 0
     Type: "ALIYUN::ECS::Instance"
     Properties:
+      InstanceName: 
+        Fn::Sub: ${EnvId}-bastion-host
+      HostName:
+        Fn::Sub: ${EnvId}-bastion-host
+      InstanceType:
+        Ref: WorkerInstanceType
+      ImageId:
+        Ref: BastionHostImageId
+      SecurityGroupId:
+        Ref: AYSecurityGroup
+      VSwitchId:
+        Ref: AYVSwitchA
+      ZoneId:
+        !Select
+          - '0'
+          - !GetAZs
+              Ref: RegionId
+      AllocatePublicIP: true
+      InternetMaxBandwidthOut:
+        Ref: InternetMaxBandwidthOut
+      KeyPairName:
+        Ref: BastionHostSSHKeyPair
+
+  AYMasterInstances:
+    Type: "ALIYUN::ECS::Instance"
+    Count: 
+      !If
+        - IsSno
+        - 1
+        - 3
+    Properties:
       InstanceName:
-        Fn::Sub: ${EnvId}-master-1
+        Fn::Sub: ${EnvId}-master-${ALIYUN::Index}
       InstanceType:
         Ref: MasterInstanceType
       ImageId:
         Ref: AIImageId
       SecurityGroupId:
         Ref: AYSecurityGroup
-      VSwitchId:
-        Ref: AYVSwitchA
-      ZoneId:
-        Ref: ZoneAId
-      AllocatePublicIP:
-        Ref: AllocatePublicIP
+      VSwitchId: 
+        !Select
+          - !Calculate
+              - "{0}%2"
+              - 0
+              - - !Ref ALIYUN::Index
+          - [!Ref AYVSwitchA, !Ref AYVSwitchB]
+      ZoneId: 
+        !Select
+          - !Calculate
+              - "{0}%2"
+              - 0
+              - - !Ref ALIYUN::Index
+          - !GetAZs
+              Ref: RegionId
+      AllocatePublicIP: false
       InternetMaxBandwidthOut:
         Ref: InternetMaxBandwidthOut
       KeyPairName:
-        Ref: KeyPairName
+        Fn::GetAtt:
+          - AYSSHKeyPair
+          - KeyPairName
       SystemDiskCategory: cloud_essd
       SystemDiskSize:
         Ref: InstanceSystemSize
@@ -412,110 +510,51 @@ Resources:
       Tags:
         - Key: Name
           Value:
-            Fn::Sub: ${EnvId}-master-1
+            Fn::Sub: ${EnvId}-master-${ALIYUN::Index}
         - Key: EnvId
           Value:
             Ref: EnvId
         - Key: node-role.kubernetes.io/master
           Value: ""
 
-  AYMasterInstance2:
+  AYWorkerInstances:
     Type: "ALIYUN::ECS::Instance"
+    Count: 
+      !If
+        - CreateWorkerInstances
+        - 3
+        - 0
     Properties:
       InstanceName:
-        Fn::Sub: ${EnvId}-master-2
-      InstanceType:
-        Ref: MasterInstanceType
-      ImageId:
-        Ref: AIImageId
-      SecurityGroupId:
-        Ref: AYSecurityGroup
-      VSwitchId:
-        Ref: AYVSwitchA
-      ZoneId:
-        Ref: ZoneAId
-      AllocatePublicIP:
-        Ref: AllocatePublicIP
-      InternetMaxBandwidthOut:
-        Ref: InternetMaxBandwidthOut
-      KeyPairName:
-        Ref: KeyPairName
-      SystemDiskCategory: cloud_essd
-      SystemDiskSize:
-        Ref: InstanceSystemSize
-      DiskMappings:
-        - Category: cloud_essd
-          Size:
-            Ref: InstanceDataSize
-      Tags:
-        - Key: Name
-          Value:
-            Fn::Sub: ${EnvId}-master-2
-        - Key: EnvId
-          Value:
-            Ref: EnvId
-        - Key: node-role.kubernetes.io/master
-          Value: ""
-
-  AYMasterInstance3:
-    Type: "ALIYUN::ECS::Instance"
-    Properties:
-      InstanceName:
-        Fn::Sub: ${EnvId}-master-3
-      InstanceType:
-        Ref: MasterInstanceType
-      ImageId:
-        Ref: AIImageId
-      SecurityGroupId:
-        Ref: AYSecurityGroup
-      VSwitchId:
-        Ref: AYVSwitchA
-      ZoneId:
-        Ref: ZoneAId
-      AllocatePublicIP:
-        Ref: AllocatePublicIP
-      InternetMaxBandwidthOut:
-        Ref: InternetMaxBandwidthOut
-      KeyPairName:
-        Ref: KeyPairName
-      SystemDiskCategory: cloud_essd
-      SystemDiskSize:
-        Ref: InstanceSystemSize
-      DiskMappings:
-        - Category: cloud_essd
-          Size:
-            Ref: InstanceDataSize
-      Tags:
-        - Key: Name
-          Value:
-            Fn::Sub: ${EnvId}-master-3
-        - Key: EnvId
-          Value:
-            Ref: EnvId
-        - Key: node-role.kubernetes.io/master
-          Value: ""
-
-  AYWorkerInstance1:
-    Type: "ALIYUN::ECS::Instance"
-    Properties:
-      InstanceName:
-        Fn::Sub: ${EnvId}-worker-1
+        Fn::Sub: ${EnvId}-worker-${ALIYUN::Index}
       InstanceType:
         Ref: WorkerInstanceType
       ImageId:
         Ref: AIImageId
       SecurityGroupId:
         Ref: AYSecurityGroup
-      VSwitchId:
-        Ref: AYVSwitchA
-      ZoneId:
-        Ref: ZoneAId
-      AllocatePublicIP:
-        Ref: AllocatePublicIP
+      VSwitchId: 
+        !Select
+          - !Calculate
+              - "{0}%2"
+              - 0
+              - - !Ref ALIYUN::Index
+          - [!Ref AYVSwitchA, !Ref AYVSwitchB]
+      ZoneId: 
+        !Select
+          - !Calculate
+              - "{0}%2"
+              - 0
+              - - !Ref ALIYUN::Index
+          - !GetAZs
+              Ref: RegionId
+      AllocatePublicIP: false
       InternetMaxBandwidthOut:
         Ref: InternetMaxBandwidthOut
       KeyPairName:
-        Ref: KeyPairName
+        Fn::GetAtt:
+          - AYSSHKeyPair
+          - KeyPairName
       SystemDiskCategory: cloud_essd
       SystemDiskSize:
         Ref: InstanceSystemSize
@@ -526,87 +565,11 @@ Resources:
       Tags:
         - Key: Name
           Value:
-            Fn::Sub: ${EnvId}-worker-1
+            Fn::Sub: ${EnvId}-worker-${ALIYUN::Index}
         - Key: EnvId
           Value:
             Ref: EnvId
         - Key: node-role.kubernetes.io/master
-          Value: ""
-
-  AYWorkerInstance2:
-    Type: "ALIYUN::ECS::Instance"
-    Properties:
-      InstanceName:
-        Fn::Sub: ${EnvId}-worker-2
-      InstanceType:
-        Ref: WorkerInstanceType
-      ImageId:
-        Ref: AIImageId
-      SecurityGroupId:
-        Ref: AYSecurityGroup
-      VSwitchId:
-        Ref: AYVSwitchA
-      ZoneId:
-        Ref: ZoneAId
-      AllocatePublicIP:
-        Ref: AllocatePublicIP
-      InternetMaxBandwidthOut:
-        Ref: InternetMaxBandwidthOut
-      KeyPairName:
-        Ref: KeyPairName
-      SystemDiskCategory: cloud_essd
-      SystemDiskSize:
-        Ref: InstanceSystemSize
-      DiskMappings:
-        - Category: cloud_essd
-          Size:
-            Ref: InstanceDataSize
-      Tags:
-        - Key: Name
-          Value:
-            Fn::Sub: ${EnvId}-worker-2
-        - Key: EnvId
-          Value:
-            Ref: EnvId
-        - Key: node-role.kubernetes.io/worker
-          Value: ""
-
-  AYWorkerInstance3:
-    Type: "ALIYUN::ECS::Instance"
-    Properties:
-      InstanceName:
-        Fn::Sub: ${EnvId}-worker-3
-      InstanceType:
-        Ref: WorkerInstanceType
-      ImageId:
-        Ref: AIImageId
-      SecurityGroupId:
-        Ref: AYSecurityGroup
-      VSwitchId:
-        Ref: AYVSwitchA
-      ZoneId:
-        Ref: ZoneAId
-      AllocatePublicIP:
-        Ref: AllocatePublicIP
-      InternetMaxBandwidthOut:
-        Ref: InternetMaxBandwidthOut
-      KeyPairName:
-        Ref: KeyPairName
-      SystemDiskCategory: cloud_essd
-      SystemDiskSize:
-        Ref: InstanceSystemSize
-      DiskMappings:
-        - Category: cloud_essd
-          Size:
-            Ref: InstanceDataSize
-      Tags:
-        - Key: Name
-          Value:
-            Fn::Sub: ${EnvId}-worker-3
-        - Key: EnvId
-          Value:
-            Ref: EnvId
-        - Key: node-role.kubernetes.io/worker
           Value: ""
    
   AYWorkerServerGroup:
@@ -618,20 +581,42 @@ Resources:
         Ref: AYVPC
       Protocol: TCP
       Servers:
-        - ServerType: Ecs
-          ServerId:
-            Ref: AYWorkerInstance1
-          Port: 443
-        - ServerType: Ecs
-          ServerId:
-            Ref: AYWorkerInstance2
-          Port: 443
-        - ServerType: Ecs
-          ServerId:
-            Ref: AYWorkerInstance3
-          Port: 443
+        !If
+          - CreateWorkerInstances
+          - - ServerType: Ecs
+              ServerId:
+                Ref: AYWorkerInstances[0]
+              Port: 443
+            - ServerType: Ecs
+              ServerId:
+                Ref: AYWorkerInstances[1]
+              Port: 443
+            - ServerType: Ecs
+              ServerId:
+                Ref: AYWorkerInstances[2]
+              Port: 443
+          - !If
+              - IsSno
+              - - ServerType: Ecs
+                  ServerId:
+                    Ref: AYMasterInstances[0]
+                  Port: 443
+              - - ServerType: Ecs
+                  ServerId:
+                    Ref: AYMasterInstances[0]
+                  Port: 443
+                - ServerType: Ecs
+                  ServerId:
+                    Ref: AYMasterInstances[1]
+                  Port: 443
+                - ServerType: Ecs
+                  ServerId:
+                    Ref: AYMasterInstances[2]
+                  Port: 443
 
   AYMasterServerGroup:
+    DependsOn: 
+      - AYMasterInstances
     Type: ALIYUN::NLB::ServerGroup
     Properties:
       ServerGroupName:
@@ -640,18 +625,44 @@ Resources:
         Ref: AYVPC
       Protocol: TCP
       Servers:
-        - ServerType: Ecs
-          ServerId:
-            Ref: AYMasterInstance1
-          Port: 6443
-        - ServerType: Ecs
-          ServerId:
-            Ref: AYMasterInstance2
-          Port: 6443
-        - ServerType: Ecs
-          ServerId:
-            Ref: AYMasterInstance3
-          Port: 6443
+        !If
+          - IsSno
+          - - ServerType: Ecs
+              ServerId:
+                Ref: AYMasterInstances[0]
+              Port: 6443
+          - - ServerType: Ecs
+              ServerId:
+                Ref: AYMasterInstances[0]
+              Port: 6443
+            - ServerType: Ecs
+              ServerId:
+                Ref: AYMasterInstances[1]
+              Port: 6443
+            - ServerType: Ecs
+              ServerId:
+                Ref: AYMasterInstances[2]
+              Port: 6443
+
+  NLBInternalListener6443:
+    Type: 'ALIYUN::NLB::Listener'
+    Properties:
+      LoadBalancerId: 
+        Ref: AYNLBInternal
+      ListenerProtocol: TCP
+      ListenerPort: 6443
+      ServerGroupId: 
+        Ref: AYMasterServerGroup
+
+  NLBInternalListener22623:
+    Type: 'ALIYUN::NLB::Listener'
+    Properties:
+      LoadBalancerId: 
+        Ref: AYNLBInternal
+      ListenerProtocol: TCP
+      ListenerPort: 22623
+      ServerGroupId: 
+        Ref: AYMasterServerGroup
 
   NLBListener6443:
     Type: 'ALIYUN::NLB::Listener'
@@ -660,16 +671,6 @@ Resources:
         Ref: AYNLB
       ListenerProtocol: TCP
       ListenerPort: 6443
-      ServerGroupId: 
-        Ref: AYMasterServerGroup
-
-  NLBListener22623:
-    Type: 'ALIYUN::NLB::Listener'
-    Properties:
-      LoadBalancerId: 
-        Ref: AYNLB
-      ListenerProtocol: TCP
-      ListenerPort: 22623
       ServerGroupId: 
         Ref: AYMasterServerGroup
 
@@ -682,7 +683,6 @@ Resources:
       ListenerPort: 80
       ServerGroupId: 
         Ref: AYWorkerServerGroup
-    
 
   NLBListener443:
     Type: 'ALIYUN::NLB::Listener'
@@ -694,6 +694,66 @@ Resources:
       ServerGroupId: 
         Ref: AYWorkerServerGroup
 
+  AYPrivateZone:
+    Type: ALIYUN::PVTZ::Zone
+    Properties:
+      ZoneName: 
+        Fn::Sub: ${ClusterName}.${DomainName}
+
+  AYPrivateZoneVpcBinder:
+    Type: ALIYUN::PVTZ::ZoneVpcBinder
+    Properties:
+      Vpcs:
+        - VpcId:
+            Ref: AYVPC
+          RegionId:
+            Ref: RegionId
+      ZoneId:
+        Fn::GetAtt:
+          - AYPrivateZone
+          - ZoneId
+
+  AYPrivateZoneAPIRecord:
+    Type: ALIYUN::PVTZ::ZoneRecord
+    Properties:
+      Rr: 'api'
+      Value:
+        Fn::GetAtt:
+          - AYNLBInternal
+          - DNSName
+      ZoneId:
+        Fn::GetAtt:
+          - AYPrivateZone
+          - ZoneId
+      Type: CNAME
+
+  AYPrivateZoneAPIINTRecord:
+    Type: ALIYUN::PVTZ::ZoneRecord
+    Properties:
+      Rr: 'api-int'
+      Value:
+        Fn::GetAtt:
+          - AYNLBInternal
+          - DNSName
+      ZoneId:
+        Fn::GetAtt:
+          - AYPrivateZone
+          - ZoneId
+      Type: CNAME
+
+  AYPrivateZoneAPPSRecord:
+    Type: ALIYUN::PVTZ::ZoneRecord
+    Properties:
+      Rr: '*.apps'
+      Value:
+        Fn::GetAtt:
+          - AYNLBInternal
+          - DNSName
+      ZoneId:
+        Fn::GetAtt:
+          - AYPrivateZone
+          - ZoneId
+      Type: CNAME
 
   AYAPIRecord:
     Type: ALIYUN::DNS::DomainRecord
@@ -702,19 +762,6 @@ Resources:
         Ref: DomainName
       RR: 
         Fn::Sub: "api.${ClusterName}"
-      Type: CNAME
-      Value:
-        Fn::GetAtt:
-          - AYNLB
-          - DNSName
-
-  AYAPIINTRecord:
-    Type: ALIYUN::DNS::DomainRecord
-    Properties:
-      DomainName:
-        Ref: DomainName
-      RR: 
-        Fn::Sub: "api-int.${ClusterName}"
       Type: CNAME
       Value:
         Fn::GetAtt:

--- a/lab-aliyun.sh.aliyun
+++ b/lab-aliyun.sh.aliyun
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
 
 source ./setup_env.sh
 source ./cluster-image-build.sh.aliyun

--- a/ros-create-stack.sh.aliyun
+++ b/ros-create-stack.sh.aliyun
@@ -6,9 +6,6 @@ AY_REGION=${AY_REGION:-"eu-central-1"}
 AY_BUCKET_NAME=${AY_BUCKET_NAME:-"lab-ay-$AY_REGION"}
 AY_BASE_DOMAIN=${AY_BASE_DOMAIN:-"alicloud-dev.devcluster.openshift.com"}
 
-AY_ZONE_A="${AY_REGION}a"
-AY_ZONE_B="${AY_REGION}b"
-
 export ALIBABA_CLOUD_REGION_ID=$AY_REGION
 
 # Check if the bucket exists
@@ -37,30 +34,36 @@ aliyun oss set-acl $AY_OBJECT_KEY public-read --region $AY_REGION
 AY_TEMPLATE_URL="https://$AY_BUCKET_NAME.oss-$AY_REGION.aliyuncs.com/$AY_OBJECT_NAME"
 AY_STACK_NAME="${AY_CLUSTER_NAME}"
 
-AY_SSH_KEY=$(cat ~/.ssh/id_rsa.pub)
-
 echo "**** Creating Stack $AY_STACK_NAME with template $AY_TEMPLATE_URL"
 
 aliyun ros CreateStack --region $AY_REGION \
     --StackName $AY_STACK_NAME \
     --Parameters.1.ParameterKey="RegionId" \
     --Parameters.1.ParameterValue="$AY_REGION" \
-    --Parameters.2.ParameterKey="ZoneAId" \
-    --Parameters.2.ParameterValue="$AY_ZONE_A" \
-    --Parameters.3.ParameterKey="ZoneBId" \
-    --Parameters.3.ParameterValue="$AY_ZONE_B" \
-    --Parameters.4.ParameterKey="PublicKeyBody" \
-    --Parameters.4.ParameterValue="$AY_SSH_KEY" \
-    --Parameters.5.ParameterKey="EnvId" \
-    --Parameters.5.ParameterValue="$AY_STACK_NAME" \
-    --Parameters.6.ParameterKey="AIImageId" \
-    --Parameters.6.ParameterValue="$AY_IMAGE_ID" \
-    --Parameters.7.ParameterKey="DomainName" \
-    --Parameters.7.ParameterValue="$AY_BASE_DOMAIN" \
-    --Parameters.8.ParameterKey="ClusterName" \
-    --Parameters.8.ParameterValue="$AY_CLUSTER_NAME" \
-    --Parameters.9.ParameterKey="KeyPairName" \
-    --Parameters.9.ParameterValue="$SSH_KEY_PAIR_NAME" \
+    --Parameters.2.ParameterKey="SSHPublicKeyBody" \
+    --Parameters.2.ParameterValue="\"${AY_SSH_KEY}\"" \
+    --Parameters.3.ParameterKey="EnvId" \
+    --Parameters.3.ParameterValue="$AY_STACK_NAME" \
+    --Parameters.4.ParameterKey="AIImageId" \
+    --Parameters.4.ParameterValue="$AY_IMAGE_ID" \
+    --Parameters.5.ParameterKey="DomainName" \
+    --Parameters.5.ParameterValue="$AY_BASE_DOMAIN" \
+    --Parameters.6.ParameterKey="ClusterName" \
+    --Parameters.6.ParameterValue="$AY_CLUSTER_NAME" \
+    --Parameters.7.ParameterKey="CreateSnoCluster" \
+    --Parameters.7.ParameterValue="${CREATE_SNO_CLUSTER:-false}" \
+    --Parameters.8.ParameterKey="CreateCompactCluster" \
+    --Parameters.8.ParameterValue="${CREATE_COMPACT_CLUSTER:-false}" \
+    --Parameters.9.ParameterKey="BationHostFlag" \
+    --Parameters.9.ParameterValue="${CREATE_BASTION_HOST:-false}" \
+    --Parameters.10.ParameterKey="BastionHostImageId" \
+    --Parameters.10.ParameterValue="${BASTION_HOST_IMAGE_ID:-'m-0xi1wndcxhwnxavcodyj'}" \
+    --Parameters.11.ParameterKey="BastionHostSSHKeyPair" \
+    --Parameters.11.ParameterValue="${BASTION_HOST_SSH_KEY_PAIR:-'openshift-qe'}" \
+    --Parameters.12.ParameterKey="MasterInstanceType" \
+    --Parameters.12.ParameterValue="${CONTROL_PLANE_INSTANCE_TYPE:-'ecs.g6.xlarge'}" \
+    --Parameters.13.ParameterKey="WorkerInstanceType" \
+    --Parameters.13.ParameterValue="${COMPUTE_INSTANCE_TYPE:-'ecs.g6.large'}" \
     --TemplateURL $AY_TEMPLATE_URL \
     --read-timeout 60 | tee .ay-stack-create.json
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,8 +1,36 @@
 #!/bin/bash
 
-export AY_REGION="us-east-1"
-export AY_BASE_DOMAIN="alicloud-qe.devcluster.openshift.com"
-export AY_PREFIX="jiwei-0612b-ali-"
-#export AY_OCP_VERSION="4.16.0-rc.4"
+# Provide the cluster configurations by setting up the global variables here for now. 
 
-export SSH_KEY_PAIR_NAME="jiwei-0606a-ali-ssh-pub-key"
+# The Alibaba Cloud region, please make sure the region has at least 2 availability zones
+export AY_REGION="us-east-1"
+# The DNS base domain
+export AY_BASE_DOMAIN="alicloud-qe.devcluster.openshift.com"
+# The cluster name prefix
+export AY_PREFIX="jiwei-ali-"
+# The OpenShift version to be installed
+export AY_OCP_VERSION="4.16.0"
+
+# The existing SSH public key file
+export SSH_PUBLIC_KEY_FILE="/root/jiwei/openshift-qe.pub"
+
+# Below 2 parameters controls the cluster's size, by default 3 control-plane machines and 3 compute/worker machines. 
+# Whether to create a Single-Node cluster
+export CREATE_SNO_CLUSTER="false"
+# Whether to create a 3-Node compact cluster
+export CREATE_COMPACT_CLUSTER="true"
+
+# The control-plane instance type
+# For Single-Node cluster, at least 8 vCPUs and 32 GiB RAM (e.g. "ecs.g6.2xlarge")
+export CONTROL_PLANE_INSTANCE_TYPE="ecs.g6.xlarge"
+# The compute/worker instance type
+export COMPUTE_INSTANCE_TYPE="ecs.g6.large"
+
+# Whether to create a bastoin host
+export CREATE_BASTION_HOST="false"
+# The existing image ID for the bastion host
+#export BASTION_HOST_IMAGE_ID="centos_stream_9_uefi_x64_20G_alibase_20240117.vhd"
+export BASTION_HOST_IMAGE_ID="m-0xi1wndcxhwnxavcodyj"
+# The existing SSH key pair to be used by the bastion host, because dynamically created 
+# SSH key pair not working for bastion host, not sure why yet.
+export BASTION_HOST_SSH_KEY_PAIR="openshift-qe"


### PR DESCRIPTION
Replacements of https://github.com/faermanj/lab-aliyun/pull/2, to include more enhancements. 

1. create SnatEntry for NatGateway
2. remove "ALIYUN::OSS::Bucket" section, and instead to use the OSS bucket `<cluster name>-bucket` which is created in `cluster-image-build.sh.aliyun`
3. add 5 new parameters, `CreateSnoCluster`, `CreateCompactCluster`, `BationHostFlag` , `BastionHostImageId` and `BastionHostSSHKeyPair`, which control the cluster size and the bastion host creation
4. provide `ssh_public_key` and `sno` parameters to `aicli create cluster...`
5. add `Intranet` NLB and the listeners, along with private dns zone and the record-sets


