### PR TITLE
more params for 'aliyun ecs ImportImage'

### DIFF
--- a/cluster-image-build.sh.aliyun
+++ b/cluster-image-build.sh.aliyun
@@ -113,10 +113,12 @@ aliyun ecs ImportImage \
     --ImageName $AY_IMAGE_NAME \
     --Architecture x86_64 \
     --Platform CoreOS \
+    --BootMode UEFI \
     --Description "OpenShift Image for ${AY_CLUSTER_NAME}" \
     --DiskDeviceMapping.1.OSSBucket $AY_BUCKET_NAME \
     --DiskDeviceMapping.1.OSSObject $AY_OBJECT_NAME \
     --DiskDeviceMapping.1.DiskImageSize $AY_OBJECT_SIZE \
+    --DiskDeviceMapping.1.Format QCOW2 \
     | tee .import-image.log.json
 
 export AY_IMAGE_ID=$(jq -r '.ImageId' .import-image.log.json)

--- a/infra/ros/template.ros.yaml
+++ b/infra/ros/template.ros.yaml
@@ -321,7 +321,7 @@ Resources:
       PortRange: "22/22"
       SourceCidrIp: "0.0.0.0/0"
 
-  AYNLB:
+  AYNLBExternal:
     Type: "ALIYUN::NLB::LoadBalancer"
     Properties:
       AddressType: "Internet"
@@ -329,7 +329,7 @@ Resources:
         Ref: RegionId
       VpcId:
         Ref: AYVPC
-      LoadBalancerName: ay-cluster-nlb
+      LoadBalancerName: ay-cluster-nlb-external
       CrossZoneEnabled: true
       ZoneMappings:
         - VSwitchId:
@@ -572,11 +572,11 @@ Resources:
         - Key: node-role.kubernetes.io/master
           Value: ""
    
-  AYWorkerServerGroup:
+  AYWorkerServerGroup443:
     Type: ALIYUN::NLB::ServerGroup
     Properties:
       ServerGroupName:
-        Fn::Sub: ${EnvId}-workers
+        Fn::Sub: ${EnvId}-workers-tcp443
       VpcId: 
         Ref: AYVPC
       Protocol: TCP
@@ -614,13 +614,55 @@ Resources:
                     Ref: AYMasterInstances[2]
                   Port: 443
 
-  AYMasterServerGroup:
+  AYWorkerServerGroup80:
+    Type: ALIYUN::NLB::ServerGroup
+    Properties:
+      ServerGroupName:
+        Fn::Sub: ${EnvId}-workers-tcp80
+      VpcId: 
+        Ref: AYVPC
+      Protocol: TCP
+      Servers:
+        !If
+          - CreateWorkerInstances
+          - - ServerType: Ecs
+              ServerId:
+                Ref: AYWorkerInstances[0]
+              Port: 80
+            - ServerType: Ecs
+              ServerId:
+                Ref: AYWorkerInstances[1]
+              Port: 80
+            - ServerType: Ecs
+              ServerId:
+                Ref: AYWorkerInstances[2]
+              Port: 80
+          - !If
+              - IsSno
+              - - ServerType: Ecs
+                  ServerId:
+                    Ref: AYMasterInstances[0]
+                  Port: 80
+              - - ServerType: Ecs
+                  ServerId:
+                    Ref: AYMasterInstances[0]
+                  Port: 80
+                - ServerType: Ecs
+                  ServerId:
+                    Ref: AYMasterInstances[1]
+                  Port: 80
+                - ServerType: Ecs
+                  ServerId:
+                    Ref: AYMasterInstances[2]
+                  Port: 80
+
+  AYMasterServerGroup6443:
     DependsOn: 
       - AYMasterInstances
     Type: ALIYUN::NLB::ServerGroup
     Properties:
       ServerGroupName:
-        Fn::Sub: ${EnvId}-masters
+        Fn::Sub: ${EnvId}-masters-tcp6443
       VpcId: 
         Ref: AYVPC
       Protocol: TCP
@@ -644,6 +686,37 @@ Resources:
                 Ref: AYMasterInstances[2]
               Port: 6443
 
+  AYMasterServerGroup22623:
+    DependsOn: 
+      - AYMasterInstances
+    Type: ALIYUN::NLB::ServerGroup
+    Properties:
+      ServerGroupName:
+        Fn::Sub: ${EnvId}-masters-tcp22623
+      VpcId: 
+        Ref: AYVPC
+      Protocol: TCP
+      Servers:
+        !If
+          - IsSno
+          - - ServerType: Ecs
+              ServerId:
+                Ref: AYMasterInstances[0]
+              Port: 22623
+          - - ServerType: Ecs
+              ServerId:
+                Ref: AYMasterInstances[0]
+              Port: 22623
+            - ServerType: Ecs
+              ServerId:
+                Ref: AYMasterInstances[1]
+              Port: 22623
+            - ServerType: Ecs
+              ServerId:
+                Ref: AYMasterInstances[2]
+              Port: 22623
+
+  # NLB internal listeners
   NLBInternalListener6443:
     Type: 'ALIYUN::NLB::Listener'
     Properties:
@@ -652,7 +725,7 @@ Resources:
       ListenerProtocol: TCP
       ListenerPort: 6443
       ServerGroupId: 
-        Ref: AYMasterServerGroup
+        Ref: AYMasterServerGroup6443
 
   NLBInternalListener22623:
     Type: 'ALIYUN::NLB::Listener'
@@ -662,37 +735,38 @@ Resources:
       ListenerProtocol: TCP
       ListenerPort: 22623
       ServerGroupId: 
-        Ref: AYMasterServerGroup
+        Ref: AYMasterServerGroup22623
 
-  NLBListener6443:
+  # NLB external listeners
+  NLBExternalListener6443:
     Type: 'ALIYUN::NLB::Listener'
     Properties:
       LoadBalancerId: 
-        Ref: AYNLB
+        Ref: AYNLBExternal
       ListenerProtocol: TCP
       ListenerPort: 6443
       ServerGroupId: 
-        Ref: AYMasterServerGroup
+        Ref: AYMasterServerGroup6443
 
-  NLBListener80:
+  NLBExternalListener80:
     Type: 'ALIYUN::NLB::Listener'
     Properties:
       LoadBalancerId: 
-        Ref: AYNLB
+        Ref: AYNLBExternal
       ListenerProtocol: TCP
       ListenerPort: 80
       ServerGroupId: 
-        Ref: AYWorkerServerGroup
+        Ref: AYWorkerServerGroup80
 
-  NLBListener443:
+  NLBExternalListener443:
     Type: 'ALIYUN::NLB::Listener'
     Properties:
       LoadBalancerId: 
-        Ref: AYNLB
+        Ref: AYNLBExternal
       ListenerProtocol: TCP
       ListenerPort: 443
       ServerGroupId: 
-        Ref: AYWorkerServerGroup
+        Ref: AYWorkerServerGroup443
 
   AYPrivateZone:
     Type: ALIYUN::PVTZ::Zone
@@ -747,7 +821,7 @@ Resources:
       Rr: '*.apps'
       Value:
         Fn::GetAtt:
-          - AYNLBInternal
+          - AYNLBExternal
           - DNSName
       ZoneId:
         Fn::GetAtt:
@@ -765,7 +839,7 @@ Resources:
       Type: CNAME
       Value:
         Fn::GetAtt:
-          - AYNLB
+          - AYNLBExternal
           - DNSName
 
   AYAPPSRecord:
@@ -778,7 +852,7 @@ Resources:
       Type: CNAME
       Value:
         Fn::GetAtt:
-          - AYNLB
+          - AYNLBExternal
           - DNSName
 
 Outputs:

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -9,7 +9,7 @@ export AY_BASE_DOMAIN="alicloud-qe.devcluster.openshift.com"
 # The cluster name prefix
 export AY_PREFIX="jiwei-ali-"
 # The OpenShift version to be installed
-export AY_OCP_VERSION="4.16.0"
+export AY_OCP_VERSION="4.17.0-ec.1"
 
 # The existing SSH public key file
 export SSH_PUBLIC_KEY_FILE="/root/jiwei/openshift-qe.pub"
@@ -18,7 +18,7 @@ export SSH_PUBLIC_KEY_FILE="/root/jiwei/openshift-qe.pub"
 # Whether to create a Single-Node cluster
 export CREATE_SNO_CLUSTER="false"
 # Whether to create a 3-Node compact cluster
-export CREATE_COMPACT_CLUSTER="true"
+export CREATE_COMPACT_CLUSTER="false"
 
 # The control-plane instance type
 # For Single-Node cluster, at least 8 vCPUs and 32 GiB RAM (e.g. "ecs.g6.2xlarge")


### PR DESCRIPTION
- Specify boot mode "UEFI" and format "QCOW2" when import ECS image, so that no "pending user action" stage during the installation. 
- Add "*.apps" dns record in the private dns zone, but using the "Internet" type NLB. 
- Configure different service groups for different service ports

FYI What's tested: 
- Single-Node cluster installation of 4.17.0-ec.1 succeeded, see [here](https://docs.google.com/document/d/1qAsSlfVUoMtteFwFWUWedYMuOCZUwYlKtmVjfB6XPfg/edit#bookmark=id.hhj8ttght7td).
- 3-Node compact cluster installation of 4.17.0-ec.1 succeeded, see [here](https://docs.google.com/document/d/1qAsSlfVUoMtteFwFWUWedYMuOCZUwYlKtmVjfB6XPfg/edit#bookmark=kix.nm6plv4lnhxp)
- 3 control-plane machines and 3 compute machines cluster installation of 4.17.0-ec.1 succeeded, see [here](https://docs.google.com/document/d/1qAsSlfVUoMtteFwFWUWedYMuOCZUwYlKtmVjfB6XPfg/edit#bookmark=kix.31hn5x4psqkd)