### PR TITLE
support resource group

### DIFF
--- a/cluster-image-build.sh.aliyun
+++ b/cluster-image-build.sh.aliyun
@@ -116,6 +116,7 @@ aliyun ecs ImportImage \
     --Architecture x86_64 \
     --Platform CoreOS \
     --BootMode UEFI \
+    --ResourceGroupId ${RESOURCE_GROUP_ID} \
     --Description "OpenShift Image for ${AY_CLUSTER_NAME}" \
     --DiskDeviceMapping.1.OSSBucket $AY_BUCKET_NAME \
     --DiskDeviceMapping.1.OSSObject $AY_OBJECT_NAME \

--- a/infra/ros/template.ros.yaml
+++ b/infra/ros/template.ros.yaml
@@ -20,24 +20,12 @@ Parameters:
   VpcCidrBlock:
     Type: String
     Default: "192.168.0.0/16"
-  VpcName:
-    Type: String
-    Default: ay-cluster-vpc
   VSwitchCidrBlockA:
     Type: String
     Default: "192.168.1.0/24"
   VSwitchCidrBlockB:
     Type: String
     Default: "192.168.2.0/24"
-  VSwitchAName:
-    Type: String
-    Default: ay-vswitch-a
-  VSwitchBName:
-    Type: String
-    Default: ay-vswitch-b
-  SecurityGroupName:
-    Type: String
-    Default: ay-cluster-sg
   # Security
   SSHPublicKeyBody:
     Description: "The file content of the SSH public key file"
@@ -65,7 +53,6 @@ Parameters:
     Default: "alicloud-dev.devcluster.openshift.com"
   ClusterName:
     Type: String
-    Default: "lab-aliyun-cluster"
   BationHostFlag:
     Description: "Whether to create a bastion host"
     Type: Boolean
@@ -75,6 +62,9 @@ Parameters:
     Type: String
   BastionHostSSHKeyPair:
     Description: "The SSH key pair to be used by the bastion host"
+    Type: String
+  ResourceGroupId: 
+    Description: "The resource group ID"
     Type: String
 
 Conditions:
@@ -109,7 +99,9 @@ Resources:
       RegionId:
         Ref: RegionId
       VpcName:
-        Ref: VpcName
+        Fn::Sub: ${EnvId}-vpc
+      ResourceGroupId:
+        Ref: ResourceGroupId
 
   AYVSwitchA:
     Type: "ALIYUN::ECS::VSwitch"
@@ -124,7 +116,7 @@ Resources:
       CidrBlock:
         Ref: VSwitchCidrBlockA
       VSwitchName:
-        Ref: VSwitchAName
+        Fn::Sub: ${EnvId}-vswitch-a
 
   AYVSwitchB:
     Type: "ALIYUN::ECS::VSwitch"
@@ -139,7 +131,7 @@ Resources:
       CidrBlock:
         Ref: VSwitchCidrBlockB
       VSwitchName:
-        Ref: VSwitchBName
+        Fn::Sub: ${EnvId}-vswitch-b
 
   AYSecurityGroup:
     Type: "ALIYUN::ECS::SecurityGroup"
@@ -149,7 +141,9 @@ Resources:
       RegionId:
         Ref: RegionId
       SecurityGroupName:
-        Ref: SecurityGroupName
+        Fn::Sub: ${EnvId}-sg
+      ResourceGroupId:
+        Ref: ResourceGroupId
 
   AYSecurityGroupIngressICMP:
     Type: "ALIYUN::ECS::SecurityGroupIngress"
@@ -329,7 +323,10 @@ Resources:
         Ref: RegionId
       VpcId:
         Ref: AYVPC
-      LoadBalancerName: ay-cluster-nlb-external
+      LoadBalancerName: 
+        Fn::Sub: ${EnvId}-nlb-external
+      ResourceGroupId:
+        Ref: ResourceGroupId
       CrossZoneEnabled: true
       ZoneMappings:
         - VSwitchId:
@@ -355,7 +352,10 @@ Resources:
         Ref: RegionId
       VpcId:
         Ref: AYVPC
-      LoadBalancerName: ay-cluster-nlb-internal
+      LoadBalancerName: 
+        Fn::Sub: ${EnvId}-nlb-internal
+      ResourceGroupId:
+        Ref: ResourceGroupId
       CrossZoneEnabled: true
       ZoneMappings:
         - VSwitchId:
@@ -379,12 +379,18 @@ Resources:
     Properties:
       Bandwidth: "100"
       InternetChargeType: "PayByTraffic"
+      Name: 
+        Fn::Sub: ${EnvId}-eip
+      ResourceGroupId:
+        Ref: ResourceGroupId
 
   AYNatGatewayA:
     Type: "ALIYUN::VPC::NatGateway"
     Properties:
       VpcId: !Ref AYVPC
       VSwitchId: !Ref AYVSwitchA
+      NatGatewayName: 
+        Fn::Sub: ${EnvId}-ngw
 
   AYEIPAAssociation:
     Type: "ALIYUN::VPC::EIPAssociation"
@@ -430,6 +436,8 @@ Resources:
         Fn::Sub: ${EnvId}-ssh-key-pair
       PublicKeyBody:
         Ref: SSHPublicKeyBody
+      ResourceGroupId:
+        Ref: ResourceGroupId
 
   AYBastionInstance:
     Count:
@@ -443,6 +451,8 @@ Resources:
         Fn::Sub: ${EnvId}-bastion-host
       HostName:
         Fn::Sub: ${EnvId}-bastion-host
+      ResourceGroupId:
+        Ref: ResourceGroupId
       InstanceType:
         Ref: WorkerInstanceType
       ImageId:
@@ -472,6 +482,10 @@ Resources:
     Properties:
       InstanceName:
         Fn::Sub: ${EnvId}-master-${ALIYUN::Index}
+      HostName:
+        Fn::Sub: ${EnvId}-master-${ALIYUN::Index}
+      ResourceGroupId:
+        Ref: ResourceGroupId
       InstanceType:
         Ref: MasterInstanceType
       ImageId:
@@ -527,6 +541,10 @@ Resources:
     Properties:
       InstanceName:
         Fn::Sub: ${EnvId}-worker-${ALIYUN::Index}
+      HostName:
+        Fn::Sub: ${EnvId}-worker-${ALIYUN::Index}
+      ResourceGroupId:
+        Ref: ResourceGroupId
       InstanceType:
         Ref: WorkerInstanceType
       ImageId:
@@ -577,6 +595,8 @@ Resources:
     Properties:
       ServerGroupName:
         Fn::Sub: ${EnvId}-workers-tcp443
+      ResourceGroupId:
+        Ref: ResourceGroupId
       VpcId: 
         Ref: AYVPC
       Protocol: TCP
@@ -619,6 +639,8 @@ Resources:
     Properties:
       ServerGroupName:
         Fn::Sub: ${EnvId}-workers-tcp80
+      ResourceGroupId:
+        Ref: ResourceGroupId
       VpcId: 
         Ref: AYVPC
       Protocol: TCP
@@ -663,6 +685,8 @@ Resources:
     Properties:
       ServerGroupName:
         Fn::Sub: ${EnvId}-masters-tcp6443
+      ResourceGroupId:
+        Ref: ResourceGroupId
       VpcId: 
         Ref: AYVPC
       Protocol: TCP
@@ -693,6 +717,8 @@ Resources:
     Properties:
       ServerGroupName:
         Fn::Sub: ${EnvId}-masters-tcp22623
+      ResourceGroupId:
+        Ref: ResourceGroupId
       VpcId: 
         Ref: AYVPC
       Protocol: TCP
@@ -773,6 +799,8 @@ Resources:
     Properties:
       ZoneName: 
         Fn::Sub: ${ClusterName}.${DomainName}
+      ResourceGroupId:
+        Ref: ResourceGroupId
 
   AYPrivateZoneVpcBinder:
     Type: ALIYUN::PVTZ::ZoneVpcBinder
@@ -857,15 +885,26 @@ Resources:
 
 Outputs:
   VPCID:
+    Description: "The cluster's VPC ID"
     Value:
       Ref: AYVPC
   VSwitchAID:
+    Description: "The cluster's 1st vSwitch ID"
     Value:
       Ref: AYVSwitchA
   VSwitchBID:
+    Description: "The cluster's 2nd vSwitch ID"
     Value:
       Ref: AYVSwitchA
   SecurityGroupID:
+    Description: "The cluster's security group ID"
     Value:
       Ref: AYSecurityGroup
+  BastionHostPublicIP:
+    Description: "The public IP address of the bastion host"
+    Condition: CreateBationHost
+    Value:
+      Fn::GetAtt
+        - AYBastionInstance
+        - PublicIp
 

--- a/my_cluster_configurations.json
+++ b/my_cluster_configurations.json
@@ -2,13 +2,14 @@
     "region": "us-east-1",
     "base_domain": "alicloud-qe.devcluster.openshift.com",
     "cluster_name_prefix": "jiwei-ali-",
-    "openshift_version": "4.17.0-ec.1",
+    "openshift_version": "4.16.2",
     "ssh_public_key_file": "/root/jiwei/openshift-qe.pub",
-    "control_plane_instance_type": "ecs.g6.2xlarge",
+    "control_plane_instance_type": "ecs.g6.xlarge",
     "compute_instance_type": "ecs.g6.large",
-    "create_sno_cluster": true,
+    "create_sno_cluster": false,
     "create_compact_cluster": false,
     "create_bastion_host": false,
     "bastion_host_image_id": "m-0xi1wndcxhwnxavcodyj",
-    "bastion_host_ssh_key_pair": "openshift-qe"
+    "bastion_host_ssh_key_pair": "openshift-qe",
+    "resource_group_id": "rg-aek2wky7lxk4f5y"
 }

--- a/ros-create-stack.sh.aliyun
+++ b/ros-create-stack.sh.aliyun
@@ -37,6 +37,7 @@ echo "$(date -u --rfc-3339=seconds) - INFO: Creating Stack $AY_STACK_NAME with t
 
 aliyun ros CreateStack --region $AY_REGION \
     --StackName $AY_STACK_NAME \
+    --ResourceGroupId ${RESOURCE_GROUP_ID} \
     --Parameters.1.ParameterKey="RegionId" \
     --Parameters.1.ParameterValue="$AY_REGION" \
     --Parameters.2.ParameterKey="SSHPublicKeyBody" \
@@ -63,6 +64,8 @@ aliyun ros CreateStack --region $AY_REGION \
     --Parameters.12.ParameterValue="${CONTROL_PLANE_INSTANCE_TYPE:-'ecs.g6.xlarge'}" \
     --Parameters.13.ParameterKey="WorkerInstanceType" \
     --Parameters.13.ParameterValue="${COMPUTE_INSTANCE_TYPE:-'ecs.g6.large'}" \
+    --Parameters.14.ParameterKey="ResourceGroupId" \
+    --Parameters.14.ParameterValue="${RESOURCE_GROUP_ID}" \
     --TemplateURL $AY_TEMPLATE_URL \
     --read-timeout 60 | tee .ay-stack-create.json
 
@@ -95,11 +98,13 @@ while true; do
   fi
 done
 
-# get InstallerInstancePublicIp from stack
-AY_INSTALLER_INSTANCE_PUBLIC_IP=$(aliyun ros GetStack --region $AY_REGION --StackId $AY_STACK_ID | jq -r '.Outputs[] | select(.OutputKey == "InstallerInstancePublicIp") | .OutputValue')
+if [[ "${CREATE_BASTION_HOST}" == "true" ]]; then
+  # get BastionHostPublicIP from stack
+  BASTION_HOST_PUBLIC_IP=$(aliyun ros GetStack --region $AY_REGION --StackId $AY_STACK_ID | jq -r '.Outputs[] | select(.OutputKey == "BastionHostPublicIP") | .OutputValue')
+  echo "Bastion host SSH: 'ssh -i <the ssh private key> cloud-user@${BASTION_HOST_PUBLIC_IP}'"
+fi
 echo "*******"
 echo "Stack Id: $AY_STACK_ID"
-echo "Installer SSH: ssh root@$AY_INSTALLER_INSTANCE_PUBLIC_IP"
 aliyun ros GetStack --StackId "$AY_STACK_ID" --region "$AY_REGION" 
 echo "*******"
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -62,3 +62,6 @@ export BASTION_HOST_IMAGE_ID
 # SSH key pair not working for bastion host, not sure why yet.
 BASTION_HOST_SSH_KEY_PAIR=$(jq -r -c .bastion_host_ssh_key_pair "${CLUSTER_CONFIGURATION_JSON}")
 export BASTION_HOST_SSH_KEY_PAIR
+
+RESOURCE_GROUP_ID=$(jq -r -c .resource_group_id "${CLUSTER_CONFIGURATION_JSON}")
+export RESOURCE_GROUP_ID

--- a/start-cluster.sh
+++ b/start-cluster.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 
 # The maximum seconds to wait for the cluster turns "ready" (to start installation)
-CLUSTER_READY_TIMEOUT=600
+CLUSTER_READY_TIMEOUT=1200
 
 # The number of cluster machines
 HOSTS_COUNT=6


### PR DESCRIPTION
- add parameter `resource_group_id`, and creating resources in the specified resource group whenever possible
- use cluster name as the name prefix for resources
- output `BastionHostPublicIP` if a bastion host is created

What's tested: 
- 3 control-plane machines and 3 compute machines cluster installation of 4.16.2 succeeded, see [here](https://docs.google.com/document/d/1qAsSlfVUoMtteFwFWUWedYMuOCZUwYlKtmVjfB6XPfg/edit#bookmark=id.kbmdbk1wmn7o)